### PR TITLE
Patch create class and prop types

### DIFF
--- a/CheckBoxList.js
+++ b/CheckBoxList.js
@@ -1,12 +1,14 @@
 'use strict';
-var React = require('react');
+var React            = require('react');
+var PropTypes        = require('prop-types');
+var CreateReactClass = require('create-react-class');
 
-module.exports = React.createClass({
+module.exports = CreateReactClass({
 	displayName: 'CheckBoxList',
 
 	propTypes: {
-		defaultData: React.PropTypes.array,
-		onChange: React.PropTypes.func
+		defaultData: PropTypes.array,
+		onChange: PropTypes.func
 	},
 
 	getInitialState: function() {

--- a/CheckBoxList.jsx
+++ b/CheckBoxList.jsx
@@ -1,13 +1,15 @@
 /** @jsx React.DOM */
 'use strict';
-var React = require('react');
+var React            = require('react');
+var PropTypes        = require('prop-types');
+var CreateReactClass = require('create-react-class');
 
-module.exports = React.createClass({
+module.exports = CreateReactClass({
 	displayName: 'CheckBoxList',
 
 	propTypes: {
-		defaultData: React.PropTypes.array,
-		onChange: React.PropTypes.func
+		defaultData: PropTypes.array,
+		onChange: PropTypes.func
 	},
 
 	getInitialState: function() {

--- a/package.json
+++ b/package.json
@@ -23,5 +23,9 @@
   "bugs": {
     "url": "https://github.com/sonyan/react-checkbox-list/issues"
   },
-  "homepage": "https://github.com/sonyan/react-checkbox-list"
+  "homepage": "https://github.com/sonyan/react-checkbox-list",
+	"dependencies": {
+		"create-react-class": "^15.6.3",
+		"prop-types": "^15.6.2"
+	}
 }


### PR DESCRIPTION
Patch for https://github.com/sonyan/react-checkbox-list/issues/6

React documentation and release notes for v15.5.0 state that React.propTypes React.createClass were depreciated in version 15.5.0.

https://reactjs.org/blog/2017/04/07/react-v15.5.0.html#new-deprecation-warnings